### PR TITLE
Create security_zone with vni_id and fix incorrect assign pool

### DIFF
--- a/aos/blueprint.py
+++ b/aos/blueprint.py
@@ -1613,6 +1613,7 @@ class AosBlueprint(AosSubsystem):
         routing_policy: dict = None,
         import_policy: str = None,
         vlan_id: int = None,
+        vni_id: int = None,
         leaf_loopback_ip_pools: list = None,
         dhcp_servers: list = None,
         timeout: int = 60,
@@ -1642,6 +1643,8 @@ class AosBlueprint(AosSubsystem):
             (str) - change the route import policy. Default is
                     "default_only
                     ["default_only", "all", "extra_only"]
+        vni_id
+            (int) - VxLAN VNI associated with the routing zone.
         vlan_id
             (int) - VLAN ID use for sub-interface tagging with external system
                     connections. Must be unique across all security zones
@@ -1681,6 +1684,7 @@ class AosBlueprint(AosSubsystem):
             "label": name,
             "vrf_name": name,
             "vlan_id": vlan_id,
+            "vni_id": vni_id
         }
 
         sz = self.create_security_zone_from_json(bp_id, sec_zone)
@@ -1694,7 +1698,7 @@ class AosBlueprint(AosSubsystem):
         # SZ leaf loopback pool
         if leaf_loopback_ip_pools:
             group_name = "leaf_loopback_ips"
-            group_path = requote_uri(f"sz:{sz['id']} {group_name}")
+            group_path = requote_uri(f"sz:{sz['id']},{group_name}")
             self.apply_resource_groups(
                 bp_id=bp_id,
                 resource_type="ip",

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -586,7 +586,7 @@ def test_create_security_zone(
     sz_id = "78eff7d7-e936-4e6e-a9f7-079b9aa45f98"
     resource_type = "ip"
     group_name = "leaf_loopback_ips"
-    group_path = requote_uri(f"sz:{sz_id} {group_name}")
+    group_path = requote_uri(f"sz:{sz_id},{group_name}")
     pool_id = "leaf-loopback-pool-id"
 
     aos_session.add_response(


### PR DESCRIPTION
**Detailed Description:**
1) adding the ability to create sz with vni_id
2) missing comma "," for group_path will cause that pool will be assign incorrectly -> which cause that on GUI you will not be able to open /staged/virtual/routing-zones (will show blank screen - tested with Apstra 4.0.2)

