### PR TITLE
update System data_class to accept null user_config

### DIFF
--- a/aos/devices.py
+++ b/aos/devices.py
@@ -62,7 +62,7 @@ class System:
             facts=d["facts"],
             services=d.get("services", []),
             status=d["status"],
-            user_config=d["user_config"],
+            user_config=d.get("user_config", {}),
         )
 
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 
 NAME = "aos-api-client"
 
-VERSION = '0.1.15'
+VERSION = '0.1.16'
 
 
 REQUIRES = (["requests==2.24.0"],)


### PR DESCRIPTION
Bug raised in issue https://github.com/Apstra/apstra-api-python/issues/11

Addressed by allowing null user_config in returned payload