### PR TITLE
added create SZ with vni_id

### DIFF
--- a/aos/blueprint.py
+++ b/aos/blueprint.py
@@ -1648,6 +1648,7 @@ class AosBlueprint(AosSubsystem):
         routing_policy: dict = None,
         import_policy: str = None,
         vlan_id: int = None,
+        vni_id: int = None,
         leaf_loopback_ip_pools: list = None,
         dhcp_servers: list = None,
         timeout: int = 60,
@@ -1677,6 +1678,8 @@ class AosBlueprint(AosSubsystem):
             (str) - change the route import policy. Default is
                     "default_only
                     ["default_only", "all", "extra_only"]
+        vni_id
+            (int) - VxLAN VNI assosiated with the routing zone
         vlan_id
             (int) - VLAN ID use for sub-interface tagging with external system
                     connections. Must be unique across all security zones
@@ -1716,6 +1719,7 @@ class AosBlueprint(AosSubsystem):
             "label": name,
             "vrf_name": name,
             "vlan_id": vlan_id,
+            "vni_id": vni_id
         }
 
         sz_task = self.create_security_zone_from_json(
@@ -1732,7 +1736,7 @@ class AosBlueprint(AosSubsystem):
         # SZ leaf loopback pool
         if leaf_loopback_ip_pools:
             group_name = "leaf_loopback_ips"
-            group_path = requote_uri(f"sz:{sz.id} {group_name}")
+            group_path = requote_uri(f"sz:{sz.id},{group_name}")
             self.apply_resource_groups(
                 bp_id=bp_id,
                 resource_type="ip",

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -589,7 +589,7 @@ def test_create_security_zone(
     sz_id = "78eff7d7-e936-4e6e-a9f7-079b9aa45f98"
     resource_type = "ip"
     group_name = "leaf_loopback_ips"
-    group_path = requote_uri(f"sz:{sz_id} {group_name}")
+    group_path = requote_uri(f"sz:{sz_id},{group_name}")
     pool_id = "leaf-loopback-pool-id"
 
     aos_session.add_response(


### PR DESCRIPTION
adding the ability to create sz with vni_id
missing comma "," for group_path will cause that pool will be assign incorrectly -> which cause that on GUI you will not be able to open /staged/virtual/routing-zones (will show blank screen - tested with Apstra 4.0.2)

