### PR TITLE
Fix for get_agent_by_id returning wrong class object

### DIFF
--- a/aos/devices.py
+++ b/aos/devices.py
@@ -211,8 +211,8 @@ class AosSystemAgents(AosSubsystem):
         for s in system_agents.get("items", []):
             yield SystemAgent.from_json(s)
 
-    def get_agent_by_id(self, system_id: str) -> Optional[System]:
-        return System.from_json(
+    def get_agent_by_id(self, system_id: str) -> Optional[SystemAgent]:
+        return SystemAgent.from_json(
             self.rest.json_resp_get(f"/api/system-agents/{system_id}")
         )
 


### PR DESCRIPTION
In SystemAgent class function get_agent_by_id returns System class object which is bug as it should return SystemAgent object instead