### PR TITLE
blueprint: Add support for blueprint fabric-addressing-policy API

### DIFF
--- a/aos/blueprint.py
+++ b/aos/blueprint.py
@@ -2191,3 +2191,44 @@ class AosBlueprint(AosSubsystem):
         vn_path = f"/api/blueprints/{bp_id}/virtual-networks-batch"
 
         return self.rest.json_resp_post(uri=vn_path, data=payload)
+
+    def get_fabric_addressing_policy(self, bp_id):
+        """
+        Return fabric-addressing-policy in a given blueprint.
+
+        Parameters
+        ----------
+        bp_id
+            (str) - ID of AOS Blueprint
+
+        Returns
+        ----------
+            (obj) json object
+        """
+        path = f'/api/blueprints/{bp_id}/fabric-addressing-policy'
+        return self.rest.json_resp_get(path)
+
+    def update_fabric_addressing_policy(self, bp_id, ipv6_enabled=None, esi_mac_msb=None):
+        """
+        Sets a fabric addressing policy for a given blueprint.
+
+        Parameters
+        ----------
+        bp_id
+            (str) - ID of AOS Blueprint
+            (bool) - (optional) enable or disable support for IPv6 virtual networks
+            (int)  - (optional) Most Significant Byte (MSB) value used for ESI MAC addresses
+        Returns
+        -------
+        """
+
+        data = {}
+
+        if ipv6_enabled:
+            data['ipv6_enabled'] = ipv6_enabled
+
+        if esi_mac_msb:
+            data['esi_mac_msb'] = esi_mac_msb
+
+        url = f'/api/blueprints/{bp_id}/fabric-addressing-policy'
+        return self.rest.patch(url, data=data)

--- a/aos/blueprint.py
+++ b/aos/blueprint.py
@@ -2208,7 +2208,12 @@ class AosBlueprint(AosSubsystem):
         path = f'/api/blueprints/{bp_id}/fabric-addressing-policy'
         return self.rest.json_resp_get(path)
 
-    def update_fabric_addressing_policy(self, bp_id, ipv6_enabled=None, esi_mac_msb=None):
+    def update_fabric_addressing_policy(
+        self,
+        bp_id,
+        ipv6_enabled=None,
+        esi_mac_msb=None
+    ):
         """
         Sets a fabric addressing policy for a given blueprint.
 
@@ -2217,7 +2222,8 @@ class AosBlueprint(AosSubsystem):
         bp_id
             (str) - ID of AOS Blueprint
             (bool) - (optional) enable or disable support for IPv6 virtual networks
-            (int)  - (optional) Most Significant Byte (MSB) value used for ESI MAC addresses
+            (int)  - (optional) Most Significant Byte (MSB) value used for
+            ESI MAC addresses
         Returns
         -------
         """

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 
 NAME = "apstra-api-python"
 
-VERSION = '0.1.20'
+VERSION = '0.1.21'
 
 
 REQUIRES = (["requests==2.24.0"],)

--- a/tests/fixtures/aos/3.3.0/blueprints/get_fabric_addressing_policy.json
+++ b/tests/fixtures/aos/3.3.0/blueprints/get_fabric_addressing_policy.json
@@ -1,0 +1,1 @@
+{"ipv6_enabled": false, "esi_mac_msb": 2}

--- a/tests/fixtures/aos/4.0.0/blueprints/get_fabric_addressing_policy.json
+++ b/tests/fixtures/aos/4.0.0/blueprints/get_fabric_addressing_policy.json
@@ -1,0 +1,1 @@
+{"ipv6_enabled": false, "esi_mac_msb": 2}

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -1573,6 +1573,7 @@ def test_get_fabric_addressing_policy(
     assert not resp['ipv6_enabled']
     assert resp['esi_mac_msb'] % 2 == 0
 
+
 def test_update_fabric_addressing_policy(
     aos_logged_in, aos_session, expected_auth_headers, aos_api_version
 ):
@@ -1584,7 +1585,10 @@ def test_update_fabric_addressing_policy(
         status=200,
     )
 
-    resp = aos_logged_in.blueprint.update_fabric_addressing_policy(bp_id=bp_id, ipv6_enabled=True)
+    aos_logged_in.blueprint.update_fabric_addressing_policy(
+        bp_id=bp_id,
+        ipv6_enabled=True
+    )
     aos_session.request.assert_called_with(
         "PATCH",
         url,
@@ -1593,7 +1597,10 @@ def test_update_fabric_addressing_policy(
         headers=expected_auth_headers,
     )
 
-    resp = aos_logged_in.blueprint.update_fabric_addressing_policy(bp_id=bp_id, esi_mac_msb=4)
+    aos_logged_in.blueprint.update_fabric_addressing_policy(
+        bp_id=bp_id,
+        esi_mac_msb=4
+    )
     aos_session.request.assert_called_with(
         "PATCH",
         url,
@@ -1602,7 +1609,11 @@ def test_update_fabric_addressing_policy(
         headers=expected_auth_headers,
     )
 
-    resp = aos_logged_in.blueprint.update_fabric_addressing_policy(bp_id=bp_id, ipv6_enabled=True, esi_mac_msb=4)
+    aos_logged_in.blueprint.update_fabric_addressing_policy(
+        bp_id=bp_id,
+        ipv6_enabled=True,
+        esi_mac_msb=4
+    )
     aos_session.request.assert_called_with(
         "PATCH",
         url,

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -1554,3 +1554,59 @@ def test_get_routing_policies(
         "static_routes": False,
         "l3edge_server_links": True,
     }
+
+
+def test_get_fabric_addressing_policy(
+    aos_logged_in, aos_session, expected_auth_headers, aos_api_version
+):
+    bp_id = 'test-bp-1'
+    aos_session.add_response(
+        'GET',
+        f"http://aos:80/api/blueprints/{bp_id}/fabric-addressing-policy",
+        status=200,
+        resp=read_fixture(
+            f'aos/{aos_api_version}/blueprints/' f'get_fabric_addressing_policy.json'
+        ),
+    )
+
+    resp = aos_logged_in.blueprint.get_fabric_addressing_policy(bp_id=bp_id)
+    assert not resp['ipv6_enabled']
+    assert resp['esi_mac_msb'] % 2 == 0
+
+def test_update_fabric_addressing_policy(
+    aos_logged_in, aos_session, expected_auth_headers, aos_api_version
+):
+    bp_id = 'test-bp-1'
+    url = f"http://aos:80/api/blueprints/{bp_id}/fabric-addressing-policy"
+    aos_session.add_response(
+        'PATCH',
+        url,
+        status=200,
+    )
+
+    resp = aos_logged_in.blueprint.update_fabric_addressing_policy(bp_id=bp_id, ipv6_enabled=True)
+    aos_session.request.assert_called_with(
+        "PATCH",
+        url,
+        json={"ipv6_enabled": True},
+        params=None,
+        headers=expected_auth_headers,
+    )
+
+    resp = aos_logged_in.blueprint.update_fabric_addressing_policy(bp_id=bp_id, esi_mac_msb=4)
+    aos_session.request.assert_called_with(
+        "PATCH",
+        url,
+        json={"esi_mac_msb": 4},
+        params=None,
+        headers=expected_auth_headers,
+    )
+
+    resp = aos_logged_in.blueprint.update_fabric_addressing_policy(bp_id=bp_id, ipv6_enabled=True, esi_mac_msb=4)
+    aos_session.request.assert_called_with(
+        "PATCH",
+        url,
+        json={"ipv6_enabled": True, "esi_mac_msb": 4},
+        params=None,
+        headers=expected_auth_headers,
+    )


### PR DESCRIPTION
Add support for blueprint fabric-addressing-policy API. 
For the details for the API, please refer to `/api/blueprints/{blueprint_id}/fabric-addressing-policy` on Apstra REST API Explorer.