### PR TITLE
Bugfix - fix searching logic for property set

### DIFF
--- a/aos/design.py
+++ b/aos/design.py
@@ -479,9 +479,9 @@ class AosPropertySets(AosSubsystem):
             property_sets = self.get_all()
             if property_sets:
                 for ps in property_sets:
-                    if ps.get("display_name") == ps_name:
+                    if ps.get("label") == ps_name:
                         return ps
-                raise AosAPIError(f"Configlet {ps_name} not found")
+                raise AosAPIError(f"Property set {ps_name} not found")
 
         return self.rest.json_resp_get(f"/api/property-sets/{ps_id}")
 


### PR DESCRIPTION
`get_property_set()` should compare based on  `label` since a key called `display_name` does not exist in the response. The original implementation causes this function to always fail. 

Here's the response sent by apstra 4.0 and 4.1 for `get_all()` property sets

```js
[{'created_at': '2022-10-25T21:10:50.155661+0000',
  'id': '4eb212b7-977b-487d-bddf-7bc71b1fe374',
  'label': 'common vlans',
  'updated_at': '2022-10-26T14:33:58.654534+0000',
  'values': {'com_vlan': '1002,1003,1151'}},
 {'created_at': '2022-10-26T18:58:26.485253+0000',
  'id': '9ddb3808-92d8-4819-a8c9-ac35b3719239',
  'label': 'common_vlans',
  'updated_at': '2022-10-26T18:58:26.485253+0000',
  'values': {'com_vlan': '1002,1003,1151'}},
 {'created_at': '2022-10-26T19:28:07.008530+0000',
  'id': '8dc16efd-0ac4-4075-b924-d9d503a4ffbc',
  'label': 'foo bar',
  'updated_at': '2022-10-26T19:28:07.008530+0000',
  'values': {'ett': 'adfadg'}}]
```

This PR fixes the search logic and rewords the error message