### PR TITLE
Bugfix - fix condition for apply_configlet() in blueprint.py

### DIFF
--- a/aos/blueprint.py
+++ b/aos/blueprint.py
@@ -752,7 +752,7 @@ class AosBlueprint(AosSubsystem):
         id_in = f"id in {system_id}"
 
         if role and system_id:
-            condition = f"{role_in} and {id_in}"
+            condition = f"{role_in} and {id_in}".replace("'",'"')
         elif role:
             condition = role_in
         elif system_id:


### PR DESCRIPTION
The current method causes the condition to render incorrectly in both apstra 4.0 and 4.1 GUI. This is due to the fact the condition pushed via the library uses single quote but apstra expects double quote in the payload. The screenshot is for 4.1, but 4.0 also shows a similar image
<img width="1178" alt="Screen Shot 2022-11-04 at 2 00 22 PM" src="https://user-images.githubusercontent.com/22392208/200045187-00e6b6bf-9d74-47ce-854a-643d3176bc4e.png">

With a simple replace of single quote with double quote, the condition renders correctly in apstra


<img width="1103" alt="Screen Shot 2022-11-04 at 2 01 24 PM" src="https://user-images.githubusercontent.com/22392208/200045391-0f347de1-4189-4405-8a5d-913ae1602c6e.png">

