### PR TITLE
blueprint: Add support for GET /api/blueprints/{bp_id}/relationships

### DIFF
--- a/aos/blueprint.py
+++ b/aos/blueprint.py
@@ -2238,3 +2238,41 @@ class AosBlueprint(AosSubsystem):
 
         url = f'/api/blueprints/{bp_id}/fabric-addressing-policy'
         return self.rest.patch(url, data=data)
+
+    def get_node_relationships(
+        self,
+        bp_id,
+        relationship_type: str = None,
+        source_id: str = None,
+        target_id: str = None
+    ):
+        """
+        Return node relationships in a given blueprint
+
+        Parameters
+        ---------
+        bp_id
+            (str) - ID of AOS Blueprint
+        relationship_type
+            (str) - (optional) type of relationship
+        source_id
+            (str) - (optional) ID of source of relationship
+        target_id
+            (str) - (optional) ID of target of relationship
+        """
+
+        url = f'/api/blueprints/{bp_id}/relationships'
+        queries = []
+
+        if relationship_type:
+            queries.append(f'relationship_type={relationship_type}')
+        if source_id:
+            queries.append(f'source_id={source_id}')
+        if target_id:
+            queries.append(f'target_id={target_id}')
+
+        if queries:
+            query_str = '&'.join(queries)
+            url += f'?{query_str}'
+
+        return self.rest.json_resp_get(url)['relationships']

--- a/aos/blueprint.py
+++ b/aos/blueprint.py
@@ -2262,17 +2262,11 @@ class AosBlueprint(AosSubsystem):
         """
 
         url = f'/api/blueprints/{bp_id}/relationships'
-        queries = []
 
-        if relationship_type:
-            queries.append(f'relationship_type={relationship_type}')
-        if source_id:
-            queries.append(f'source_id={source_id}')
-        if target_id:
-            queries.append(f'target_id={target_id}')
+        params = {
+            'relationship_type': relationship_type,
+            'source_id': source_id,
+            'target_id': target_id
+        }
 
-        if queries:
-            query_str = '&'.join(queries)
-            url += f'?{query_str}'
-
-        return self.rest.json_resp_get(url)['relationships']
+        return self.rest.json_resp_get(url, params=params)['relationships']

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 
 NAME = "apstra-api-python"
 
-VERSION = '0.2.0'
+VERSION = '0.2.1'
 
 
 REQUIRES = (["requests==2.24.0"],)

--- a/tests/fixtures/aos/3.3.0/blueprints/get_relationships.json
+++ b/tests/fixtures/aos/3.3.0/blueprints/get_relationships.json
@@ -1,0 +1,28 @@
+{
+  "relationships": {
+    "nnJEIevQlNSjwAgVE3I": {
+      "tags": null,
+      "source_id": "y0D9CFzGPmBmGILP3Mk",
+      "target_id": "C36GOMzvZZW1uQqGQQY",
+      "property_set": null,
+      "type": "composed_of_systems",
+      "id": "nnJEIevQlNSjwAgVE3I"
+    },
+    "jbQgo_63gfCxgiKIe6g": {
+      "tags": null,
+      "source_id": "Generic_Server_1RU_2x10G_Centos__AOS-2x10-1",
+      "target_id": "Nw5QmnTrk8-0_5ISLWs",
+      "property_set": null,
+      "type": "device_profile",
+      "id": "jbQgo_63gfCxgiKIe6g"
+    },
+    "TqXFFIYLduOVpqW9eU0": {
+      "tags": null,
+      "source_id": "xX00o5Alv6f6WGbMprw",
+      "target_id": "bTqiHdi9nhVWqt1jhUE",
+      "property_set": null,
+      "type": "composed_of",
+      "id": "TqXFFIYLduOVpqW9eU0"
+    }
+  }
+}

--- a/tests/fixtures/aos/4.0.0/blueprints/get_relationships.json
+++ b/tests/fixtures/aos/4.0.0/blueprints/get_relationships.json
@@ -1,0 +1,28 @@
+{
+  "relationships": {
+    "nnJEIevQlNSjwAgVE3I": {
+      "tags": null,
+      "source_id": "y0D9CFzGPmBmGILP3Mk",
+      "target_id": "C36GOMzvZZW1uQqGQQY",
+      "property_set": null,
+      "type": "composed_of_systems",
+      "id": "nnJEIevQlNSjwAgVE3I"
+    },
+    "jbQgo_63gfCxgiKIe6g": {
+      "tags": null,
+      "source_id": "Generic_Server_1RU_2x10G_Centos__AOS-2x10-1",
+      "target_id": "Nw5QmnTrk8-0_5ISLWs",
+      "property_set": null,
+      "type": "device_profile",
+      "id": "jbQgo_63gfCxgiKIe6g"
+    },
+    "TqXFFIYLduOVpqW9eU0": {
+      "tags": null,
+      "source_id": "xX00o5Alv6f6WGbMprw",
+      "target_id": "bTqiHdi9nhVWqt1jhUE",
+      "property_set": null,
+      "type": "composed_of",
+      "id": "TqXFFIYLduOVpqW9eU0"
+    }
+  }
+}

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -1623,3 +1623,91 @@ def test_update_fabric_addressing_policy(
         params=None,
         headers=expected_auth_headers,
     )
+
+
+def test_get_node_relationships(
+    aos_logged_in, aos_session, expected_auth_headers, aos_api_version
+):
+    bp_id = 'test-bp-1'
+    url = f"http://aos:80/api/blueprints/{bp_id}/relationships"
+    aos_session.add_response(
+        'GET',
+        url,
+        status=200,
+        resp=read_fixture(
+            f'aos/{aos_api_version}/blueprints/' f'get_relationships.json'
+        ),
+    )
+    aos_logged_in.blueprint.get_node_relationships(bp_id=bp_id)
+
+    url = (
+        f"http://aos:80/api/blueprints/{bp_id}/relationships?"
+        "relationship_type=composed_of_systems"
+    )
+    aos_session.add_response(
+        'GET',
+        url,
+        status=200,
+        resp=read_fixture(
+            f'aos/{aos_api_version}/blueprints/' f'get_relationships.json'
+        ),
+    )
+    aos_logged_in.blueprint.get_node_relationships(
+        bp_id=bp_id,
+        relationship_type='composed_of_systems'
+    )
+
+    url = (
+        f"http://aos:80/api/blueprints/{bp_id}/relationships?"
+        "source_id=y0D9CFzGPmBmGILP3Mk"
+    )
+    aos_session.add_response(
+        'GET',
+        url,
+        status=200,
+        resp=read_fixture(
+            f'aos/{aos_api_version}/blueprints/' f'get_relationships.json'
+        ),
+    )
+    aos_logged_in.blueprint.get_node_relationships(
+        bp_id=bp_id,
+        source_id='y0D9CFzGPmBmGILP3Mk'
+    )
+
+    url = (
+        f"http://aos:80/api/blueprints/{bp_id}/relationships?"
+        "target_id=C36GOMzvZZW1uQqGQQY"
+    )
+    aos_session.add_response(
+        'GET',
+        url,
+        status=200,
+        resp=read_fixture(
+            f'aos/{aos_api_version}/blueprints/' f'get_relationships.json'
+        ),
+    )
+    aos_logged_in.blueprint.get_node_relationships(
+        bp_id=bp_id,
+        target_id='C36GOMzvZZW1uQqGQQY'
+    )
+
+    url = (
+        f"http://aos:80/api/blueprints/{bp_id}/relationships?"
+        "relationship_type=composed_of_systems&"
+        "source_id=y0D9CFzGPmBmGILP3Mk&"
+        "target_id=C36GOMzvZZW1uQqGQQY"
+    )
+    aos_session.add_response(
+        'GET',
+        url,
+        status=200,
+        resp=read_fixture(
+            f'aos/{aos_api_version}/blueprints/' f'get_relationships.json'
+        ),
+    )
+    aos_logged_in.blueprint.get_node_relationships(
+        bp_id=bp_id,
+        relationship_type='composed_of_systems',
+        source_id='y0D9CFzGPmBmGILP3Mk',
+        target_id='C36GOMzvZZW1uQqGQQY'
+    )

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -1634,20 +1634,26 @@ def test_get_node_relationships(
         'GET',
         url,
         status=200,
+        params={
+            'relationship_type': None,
+            'source_id': None,
+            'target_id': None
+        },
         resp=read_fixture(
             f'aos/{aos_api_version}/blueprints/' f'get_relationships.json'
         ),
     )
     aos_logged_in.blueprint.get_node_relationships(bp_id=bp_id)
 
-    url = (
-        f"http://aos:80/api/blueprints/{bp_id}/relationships?"
-        "relationship_type=composed_of_systems"
-    )
     aos_session.add_response(
         'GET',
         url,
         status=200,
+        params={
+            'relationship_type': 'composed_of_systems',
+            'source_id': None,
+            'target_id': None
+        },
         resp=read_fixture(
             f'aos/{aos_api_version}/blueprints/' f'get_relationships.json'
         ),
@@ -1657,14 +1663,15 @@ def test_get_node_relationships(
         relationship_type='composed_of_systems'
     )
 
-    url = (
-        f"http://aos:80/api/blueprints/{bp_id}/relationships?"
-        "source_id=y0D9CFzGPmBmGILP3Mk"
-    )
     aos_session.add_response(
         'GET',
         url,
         status=200,
+        params={
+            'relationship_type': None,
+            'source_id': 'y0D9CFzGPmBmGILP3Mk',
+            'target_id': None
+        },
         resp=read_fixture(
             f'aos/{aos_api_version}/blueprints/' f'get_relationships.json'
         ),
@@ -1674,14 +1681,15 @@ def test_get_node_relationships(
         source_id='y0D9CFzGPmBmGILP3Mk'
     )
 
-    url = (
-        f"http://aos:80/api/blueprints/{bp_id}/relationships?"
-        "target_id=C36GOMzvZZW1uQqGQQY"
-    )
     aos_session.add_response(
         'GET',
         url,
         status=200,
+        params={
+            'relationship_type': None,
+            'source_id': None,
+            'target_id': 'C36GOMzvZZW1uQqGQQY'
+        },
         resp=read_fixture(
             f'aos/{aos_api_version}/blueprints/' f'get_relationships.json'
         ),
@@ -1691,16 +1699,15 @@ def test_get_node_relationships(
         target_id='C36GOMzvZZW1uQqGQQY'
     )
 
-    url = (
-        f"http://aos:80/api/blueprints/{bp_id}/relationships?"
-        "relationship_type=composed_of_systems&"
-        "source_id=y0D9CFzGPmBmGILP3Mk&"
-        "target_id=C36GOMzvZZW1uQqGQQY"
-    )
     aos_session.add_response(
         'GET',
         url,
         status=200,
+        params={
+            'relationship_type': 'composed_of_systems',
+            'source_id': 'y0D9CFzGPmBmGILP3Mk',
+            'target_id': 'C36GOMzvZZW1uQqGQQY'
+        },
         resp=read_fixture(
             f'aos/{aos_api_version}/blueprints/' f'get_relationships.json'
         ),


### PR DESCRIPTION
Add support for GET `/api/blueprints/{bp_id}/relationships`
This API is useful in some use cases like finding a pair of interface and device.