### PR TITLE
create_switch_system_links missing return

### DIFF
--- a/aos/blueprint.py
+++ b/aos/blueprint.py
@@ -972,7 +972,7 @@ class AosBlueprint(AosSubsystem):
     def create_switch_system_links(self, bp_id: str, data: dict):
         uri = f"/api/blueprints/{bp_id}/switch-system-links"
 
-        self.rest.json_resp_post(uri, data=data)
+        return self.rest.json_resp_post(uri, data=data)
 
     def get_cabling_map(self, bp_id: str) -> Dict:
         """


### PR DESCRIPTION
As it doesn't have a return - always return None.
In the fix - it will return link IDs. ie:
{'ids': ['Leaf1<->Server3(eth0)[1]', 'Leaf2<->Server3(eth1)[1]', 'Leaf1<->Server3(lag0)[1]', 'Leaf2<->Server3(lag0)[1]']}