### PR TITLE
get_cabling_map not working in 4.1.2

### DIFF
--- a/aos/blueprint.py
+++ b/aos/blueprint.py
@@ -987,7 +987,7 @@ class AosBlueprint(AosSubsystem):
         -------
             (dict) - cable map information
         """
-        return self.rest.json_resp_get(f"/api/blueprints/{bp_id}/cabling-map")
+        return self.rest.json_resp_get(f"/api/blueprints/{bp_id}/experience/web/cabling-map")
 
     def update_cabling_map(self, bp_id: str, links: List[dict]):
         """


### PR DESCRIPTION
im using 4.1.2 and path "/api/blueprints/{bp_id}/cabling-map" is incorrect for GET. correct path: "/api/blueprints/{bp_id}/experience/web/cabling-map"